### PR TITLE
Add ruby scaffold

### DIFF
--- a/jefe-cli.sh
+++ b/jefe-cli.sh
@@ -81,26 +81,6 @@ init() {
     tput setaf 2;
     cat .jefe/logo.txt
 
-    # create every folder needed
-
-    out "Make directory structure." 4
-
-    echo "Creating app directory..."
-    if [[ ! -d "./app" ]]; then
-        mkdir ./app
-        out "done" 2
-    else
-        out "it already exists." 3
-    fi
-
-    echo "Creating database directory..."
-    if [[ ! -d "./database" ]]; then
-        mkdir ./database
-        out "done" 2
-    else
-        out "it already exists." 3
-    fi
-
     ###############################################################################################
     # Configure project
     ###############################################################################################
@@ -161,6 +141,25 @@ init() {
 
     # Config environments.
     config_environments
+}
+
+create_folder_structure() {
+    out "Make directory structure." 4
+    echo "Creating app directory..."
+    if [[ ! -d "./${project_root}" ]]; then
+        mkdir ./${project_root}
+        out "done" 2
+    else
+        out "it already exists." 3
+    fi
+
+    echo "Creating database directory..."
+    if [[ ! -d "./database" ]]; then
+        mkdir ./database
+        out "done" 2
+    else
+        out "it already exists." 3
+    fi
 }
 
 up() {
@@ -470,6 +469,37 @@ configure_php_project() {
 # configure ruby project
 configure_ruby_project() {
     load_dotenv
+
+    create_folder_structure
+
+    out "Select type of project ruby" 5
+    out "0) Ripper Rails API Project" 5
+    echo "Type the option (number) that you want(digit), followed by [ENTER]:"
+    read option
+    flag=true
+    while [ $flag = true ]; do
+        echo $option
+        case $option in
+            0)
+                cd ./${project_root}
+                git clone https://github.com/ricardo-pcan/ripper-rails-scaffold.git .
+                rm -rf .git
+                cp .circle.yml ../circle.yml
+                rm .circle.yml
+                rm -f ../.gitignore
+                cp .gitignore ../.gitignore
+                rm .gitignore
+                cp .env.example .env
+                cd ..
+                flag=false
+                ;;
+            *)
+                out "Wrong choice:$option" 1
+                project=""
+                flag=true
+                ;;
+        esac
+    done
     cp .jefe/postinstall.sh ./$project_root/postinstall.sh
 }
 

--- a/jefe-cli.sh
+++ b/jefe-cli.sh
@@ -548,6 +548,11 @@ docker_env() {
     fi
 }
 
+logs() {
+    cd ./.jefe
+    docker-compose logs -f
+}
+
 # Config environments.
 config_environments() {
     out "Config environments.." 4

--- a/jefe-cli.sh
+++ b/jefe-cli.sh
@@ -394,25 +394,6 @@ it() {
     cd ..
 }
 
-logs() {
-    while getopts ":c:" option; do
-        case "${option}" in
-            c)
-                c=${OPTARG}
-                ;;
-        esac
-    done
-    shift $((OPTIND-1))
-
-    if [ -z "${c}" ]; then
-        c="docker-php_php"
-    fi
-
-    cd .jefe/
-    fab logs:${c}
-    cd ..
-}
-
 # configure php project
 configure_php_project() {
     create_folder_structure
@@ -552,6 +533,7 @@ docker_env() {
 logs() {
     cd ./.jefe
     docker-compose logs -f
+    cd ..
 }
 
 # Config environments.

--- a/jefe-cli.sh
+++ b/jefe-cli.sh
@@ -415,6 +415,7 @@ logs() {
 
 # configure php project
 configure_php_project() {
+    create_folder_structure
     flag=true
     while [ $flag = true ]; do
         out "Select project:" 5


### PR DESCRIPTION
# Task
Add ruby scaffold option  for ruby languaje to jefe script.
This scaffold is based on [ricardo-pcan/ripper-rails-scaffold](https://github.com/ricardo-pcan/ripper-rails-scaffold.git).

This scaffold contains the configuration and gems that required for vinco rails projects.

# Action plan
We add and modify the flow for `init` task.
We add task `create_folder_structure`, this task is made for separate the folder structure creation from init and this action allow that creates folder that set into `project_root`.

Also we add some line into `configure_ruby_project` and add choice with ripper-rails-scaffold.

We also add `logs` task, this task runs the `docker-compose logs -f` command for watch all logs from containers.